### PR TITLE
rockchip: Enable KVM in kernel 6.6

### DIFF
--- a/package/kernel/linux/modules/virt.mk
+++ b/package/kernel/linux/modules/virt.mk
@@ -78,7 +78,7 @@ $(eval $(call KernelPackage,kvm-amd))
 define KernelPackage/vfio
   SUBMENU:=Virtualization
   TITLE:=VFIO Non-Privileged userspace driver framework
-  DEPENDS:=@TARGET_x86_64||TARGET_armsr_armv8
+  DEPENDS:=@TARGET_x86_64||TARGET_armsr_armv8||TARGET_rockship_armv8
   KCONFIG:= \
 	CONFIG_VFIO \
 	CONFIG_VFIO_NOIOMMU=n \


### PR DESCRIPTION
Enable hypervisor using hardware virtualisation support on supported Rochchip devices[1].

As per [OpenWRT's Hardware DB](https://openwrt.org/toh/views/toh_extended_all), OpenWRT supports the following rockchip SOCs RK3399/RK3328/RK3566/RK3568/RK3568B2/RK3588/RK3588S/RK3308B/RK3568(J) and all of them have the following properties:

- all have SD card support => image size increase due to new kernel config changes are mitigated.
- all have min 256Mb ram (with the large majority actually having 1G/4G RAM).
- performance: On the only tested device (NanoPi R4s 4G), no notable performance regression observed.

Tested on: NanoPi R4S (4G ram)
Kernel size change: untested for now (one other had [3.3% kernel size increase](https://github.com/openwrt/openwrt/pull/17495))

Related:
- https://github.com/openwrt/packages/pull/26797
